### PR TITLE
Add Tasks and Favorites features with route and DB support

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,6 +4,8 @@ import morgan from 'morgan';
 
 import authRoutes from './routes/auth.js';
 import userRoutes from './routes/users.js';
+import favoriteRoutes from './routes/favorites.js';
+import taskRoutes from './routes/tasks.js';
 
 const app = express();
 
@@ -12,9 +14,12 @@ app.use(cors());
 app.use(express.json());
 app.use(morgan('dev'));
 
+
 // Routes
 app.use('/api', authRoutes);
 app.use('/api/user', userRoutes);
+app.use('/api/favorites', favoriteRoutes);
+app.use('/api/tasks', taskRoutes);
 
 // Health check
 app.get('/', (req, res) => {

--- a/db/queries/favorites.js
+++ b/db/queries/favorites.js
@@ -1,0 +1,28 @@
+import db from "../client.js";
+
+// Create a favorite
+export async function createFavorite({ user_id, trip_id }) {
+  const { rows: [favorite] } = await db.query(
+    "INSERT INTO favorite (user_id, trip_id) VALUES ($1, $2) RETURNING *;",
+    [user_id, trip_id]
+  );
+  return favorite;
+}
+
+// Get all favorites for a specific user
+export async function getFavoritesByUser(user_id) {
+  const { rows } = await db.query(
+    "SELECT * FROM favorite WHERE user_id = $1;",
+    [user_id]
+  );
+  return rows;
+}
+
+// Delete a favorite
+export async function deleteFavorite({ user_id, trip_id }) {
+  const { rows: [deleted] } = await db.query(
+    "DELETE FROM favorite WHERE user_id = $1 AND trip_id = $2 RETURNING *;",
+    [user_id, trip_id]
+  );
+  return deleted;
+}

--- a/db/queries/tasks.js
+++ b/db/queries/tasks.js
@@ -1,0 +1,44 @@
+import db from '../client.js';
+
+// Create a task
+export async function createTask({ trip_id, title, description, due_date, assigned_to, created_by }) {
+  const { rows: [task] } = await db.query(
+    `INSERT INTO task (trip_id, title, description, due_date, assigned_to, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6)
+     RETURNING *;`,
+    [trip_id, title, description, due_date, assigned_to, created_by]
+  );
+  return task;
+}
+
+// Get tasks by trip_id
+export async function getTasksByTripId(trip_id) {
+  const { rows } = await db.query(
+    `SELECT * FROM task WHERE trip_id = $1 ORDER BY due_date ASC;`,
+    [trip_id]
+  );
+  return rows;
+}
+
+// Update a task
+export async function updateTask(id, updates) {
+  const fields = Object.keys(updates);
+  const values = Object.values(updates);
+
+  const setString = fields.map((field, index) => `${field} = $${index + 1}`).join(', ');
+
+  const { rows: [updated] } = await db.query(
+    `UPDATE task SET ${setString}, updated_at = CURRENT_TIMESTAMP WHERE id = $${fields.length + 1} RETURNING *;`,
+    [...values, id]
+  );
+  return updated;
+}
+
+// Delete a task
+export async function deleteTask(id) {
+  const { rows: [deleted] } = await db.query(
+    `DELETE FROM task WHERE id = $1 RETURNING *;`,
+    [id]
+  );
+  return deleted;
+}

--- a/routes/favorites.js
+++ b/routes/favorites.js
@@ -1,0 +1,58 @@
+import express from 'express';
+import { createFavorite, getFavoritesByUser, deleteFavorite } from '../db/queries/favorites.js';
+import requireUser from '../middleware/auth.js';
+
+const router = express.Router();
+
+// GET /api/favorites - Get all favorites for the logged-in user
+router.get('/', requireUser, async (req, res) => {
+  try {
+    const user_id = req.user.id;
+    const favorites = await getFavoritesByUser(user_id);
+    res.json({ favorites });
+  } catch (err) {
+    console.error('❌ Error fetching favorites:', err);
+    res.status(500).json({ error: 'Failed to fetch favorites' });
+  }
+});
+
+// POST /api/favorites - Add a favorite trip for the logged-in user
+router.post('/', requireUser, async (req, res) => {
+  const user_id = req.user.id;
+  const { trip_id } = req.body;
+
+  if (!trip_id) {
+    return res.status(400).json({ error: 'trip_id is required' });
+  }
+
+  try {
+    const favorite = await createFavorite({ user_id, trip_id });
+    res.status(201).json({ favorite });
+  } catch (err) {
+    console.error('❌ Error adding favorite:', err);
+    res.status(500).json({ error: 'Failed to add favorite' });
+  }
+});
+
+// DELETE /api/favorites - Remove a favorite trip for the logged-in user
+router.delete('/', requireUser, async (req, res) => {
+  const user_id = req.user.id;
+  const { trip_id } = req.body;
+
+  if (!trip_id) {
+    return res.status(400).json({ error: 'trip_id is required' });
+  }
+
+  try {
+    const deleted = await deleteFavorite({ user_id, trip_id });
+    if (!deleted) {
+      return res.status(404).json({ error: 'Favorite not found' });
+    }
+    res.json({ message: 'Favorite removed', deleted });
+  } catch (err) {
+    console.error('❌ Error removing favorite:', err);
+    res.status(500).json({ error: 'Failed to remove favorite' });
+  }
+});
+
+export default router;

--- a/routes/tasks.js
+++ b/routes/tasks.js
@@ -1,0 +1,72 @@
+import express from 'express';
+import requireUser from '../middleware/auth.js';
+import {
+  createTask,
+  getTasksByTripId,
+  updateTask,
+  deleteTask
+} from '../db/queries/tasks.js';
+
+const router = express.Router();
+
+// POST /api/tasks
+router.post('/', requireUser, async (req, res) => {
+  try {
+    const { trip_id, title, description, due_date, assigned_to } = req.body;
+    const created_by = req.user.id;
+
+    const task = await createTask({
+      trip_id,
+      title,
+      description,
+      due_date,
+      assigned_to,
+      created_by
+    });
+
+    res.status(201).json({ task });
+  } catch (err) {
+    console.error('❌ Error creating task:', err);
+    res.status(500).json({ error: 'Failed to create task' });
+  }
+});
+
+// GET /api/tasks/:trip_id
+router.get('/:trip_id', requireUser, async (req, res) => {
+  try {
+    const { trip_id } = req.params;
+    const tasks = await getTasksByTripId(trip_id);
+    res.json({ tasks });
+  } catch (err) {
+    console.error('❌ Error fetching tasks:', err);
+    res.status(500).json({ error: 'Failed to fetch tasks' });
+  }
+});
+
+// PATCH /api/tasks/:id
+router.patch('/:id', requireUser, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updates = req.body;
+
+    const task = await updateTask(id, updates);
+    res.json({ task });
+  } catch (err) {
+    console.error('❌ Error updating task:', err);
+    res.status(500).json({ error: 'Failed to update task' });
+  }
+});
+
+// DELETE /api/tasks/:id
+router.delete('/:id', requireUser, async (req, res) => {
+  try {
+    const { id } = req.params;
+    const deleted = await deleteTask(id);
+    res.json({ message: 'Task deleted', deleted });
+  } catch (err) {
+    console.error('❌ Error deleting task:', err);
+    res.status(500).json({ error: 'Failed to delete task' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
This PR adds backend support for Tasks and Favorites:

-- routes/tasks.js + db/queries/tasks.js: Create, view, update, and delete tasks tied to a trip

--routes/favorites.js + db/queries/favorites.js: Add, view, delete favorite trips for a user

--app.js: Updated to include route handlers for /api/tasks and /api/favorites